### PR TITLE
Dockerfile gives error on pip3 lines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Docker Buildfile for the ycast-docker container based on alpine linux - about 41.4MB
 # put dockerfile and bootstrap.sh in same directory and build or enter
-# docker build  https://github.com/MaartenSanders/ycast-docker.git#:docker
+# docker build https://github.com/ThHanika/YCast.git#:docker
 #
 FROM alpine:latest
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Docker Buildfile for the ycast-docker container based on alpine linux - about 41.4MB
 # put dockerfile and bootstrap.sh in same directory and build or enter
-# docker build  https://github.com/MaartenSanders/ycast-docker.git
+# docker build  https://github.com/MaartenSanders/ycast-docker.git#:docker
 #
 FROM alpine:latest
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,11 +29,11 @@ RUN apk --no-cache update && \
     apk add --no-cache jpeg-dev && \
     apk add --no-cache build-base && \
     apk add --no-cache python3-dev && \
-    pip3 install --no-cache-dir requests && \
-    pip3 install --no-cache-dir flask && \
-    pip3 install --no-cache-dir PyYAML && \
-    pip3 install --no-cache-dir Pillow  && \
-    pip3 install --no-cache-dir olefile && \
+    pip3 install --no-cache-dir requests --break-system-packages && \
+    pip3 install --no-cache-dir flask --break-system-packages && \
+    pip3 install --no-cache-dir PyYAML --break-system-packages && \
+    pip3 install --no-cache-dir Pillow  --break-system-packages && \
+    pip3 install --no-cache-dir olefile --break-system-packages && \
     mkdir -p /opt/ycast/YCast-master && \
     apk del --no-cache python3-dev && \
     apk del --no-cache build-base && \


### PR DESCRIPTION
I experienced errors with the dockerfile on Ubuntu and Debian.

The problem was fixed with the option --break-system-packages to pip3 install lines in the Dockerfile.

Also I changed the direct docker build commandline in the comments to:
`# docker build https://github.com/ThHanika/YCast.git#:docker`

Error without fix:
```
10.40 Executing busybox-1.36.1-r15.trigger
10.41 OK: 359 MiB in 67 packages
12.52 error: externally-managed-environment
12.52 
12.52 × This environment is externally managed
12.52 ╰─> 
12.52     The system-wide python installation should be maintained using the system
12.52     package manager (apk) only.
12.52     
12.52     If the package in question is not packaged already (and hence installable via
12.52     "apk add py3-somepackage"), please consider installing it inside a virtual
12.52     environment, e.g.:
12.52     
12.52     python3 -m venv /path/to/venv
12.52     . /path/to/venv/bin/activate
12.52     pip install mypackage
12.52     
12.52     To exit the virtual environment, run:
12.52     
12.52     deactivate
12.52     
12.52     The virtual environment is not deleted, and can be re-entered by re-sourcing
12.52     the activate file.
12.52     
12.52     To automatically manage virtual environments, consider using pipx (from the
12.52     pipx package).
12.52 
12.52 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
12.52 hint: See PEP 668 for the detailed specification.
```