### PR TITLE
Add entry_points in setup.py to enable installation via pipx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     url='https://github.com/milaq/YCast',
+    entry_points={"console_scripts": ["ycast=ycast.__main__:launch_server"]},
     license='GPLv3',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This little fix is necessary to do a pipx install. 
Then ycast can be directly launched from cmd.
See: https://setuptools.pypa.io/en/latest/userguide/entry_point.html